### PR TITLE
Allow checking for message version and payload in assert_message_not_published

### DIFF
--- a/hedwig/testing/pytest_plugin.py
+++ b/hedwig/testing/pytest_plugin.py
@@ -14,6 +14,15 @@ class HedwigPublishMock(mock.MagicMock):
     Custom mock class used by :meth:`hedwig.testing.pytest_plugin.mock_hedwig_publish` to mock the publisher.
     """
 
+    def _message_published(self, msg_type, data: Optional[dict], version: Union[str, StrictVersion]) -> bool:
+        return any(
+            msg.type == msg_type and (data is None or msg.data) == data and msg.data_schema_version == version
+            for (msg,), _ in self.call_args_list
+        )
+
+    def _error_message(self) -> str:
+        return pprint.pformat([(msg.type, msg.data, msg.data_schema_version) for (msg,), _ in self.call_args_list])
+
     def assert_message_published(
         self, msg_type, data: Optional[dict] = None, version: Union[str, StrictVersion] = StrictVersion('1.0')
     ) -> None:
@@ -24,18 +33,19 @@ class HedwigPublishMock(mock.MagicMock):
         if not isinstance(version, StrictVersion):
             version = StrictVersion(version)
 
-        assert any(
-            msg.type == msg_type and (data is None or msg.data) == data and msg.data_schema_version == version
-            for (msg,), _ in self.call_args_list
-        ), pprint.pformat([(msg.type, msg.data, msg.data_schema_version) for (msg,), _ in self.call_args_list])
+        assert self._message_published(msg_type, data, version), self._error_message()
 
-    def assert_message_not_published(self, msg_type) -> None:
+    def assert_message_not_published(
+        self, msg_type, data: Optional[dict] = None, version: Union[str, StrictVersion] = StrictVersion('1.0')
+    ) -> None:
         """
-        Helper function to check that a Hedwig message of given type was NOT sent.
+        Helper function to check that a Hedwig message of given type, data
+        and schema was NOT sent.
         """
-        assert all(msg.type != msg_type for (msg,), _ in self.call_args_list), pprint.pformat(
-            [(msg.type, msg.data, msg.data_schema_version) for (msg,), _ in self.call_args_list]
-        )
+        if not isinstance(version, StrictVersion):
+            version = StrictVersion(version)
+
+        assert not self._message_published(msg_type, data, version), self._error_message()
 
 
 @pytest.fixture()

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -18,6 +18,10 @@ def test_plugin(testdir):
         @pytest.fixture()
         def message(message_data):
             return Message(message_data)
+
+        @pytest.fixture(name='other_message_data')
+        def _other_message_data():
+            return MessageFactory.build(msg_type=MessageType.trip_created)
     """
     )
 
@@ -36,6 +40,12 @@ def test_plugin(testdir):
             mock_hedwig_publish.assert_message_not_published(MessageType.device_created)
 
 
+        def test_mock_hedwig_publish_publish_check_same_type(mock_hedwig_publish, message, other_message_data):
+            message.publish()
+            mock_hedwig_publish.assert_message_not_published(message.type, data=other_message_data)
+            mock_hedwig_publish.assert_message_published(message.type, data=message.data, version=message.data_schema_version)
+
+
         def test_mock_hedwig_publish_published(mock_hedwig_publish, message):
             message.publish()
             mock_hedwig_publish.assert_message_published(message.type, data=message.data, version=message.data_schema_version)
@@ -46,4 +56,4 @@ def test_plugin(testdir):
     result = testdir.runpytest()
 
     # check that all 3 tests passed
-    result.assert_outcomes(passed=3)
+    result.assert_outcomes(passed=4)


### PR DESCRIPTION
Use case: a loop which sends messages only if a condition was met.

    for d in data_set:
        if should_handle(d):
            send_message(MessageType.data_handled, d)

In order to test it `assert_message_not_published` must recognize messages of the same type, but different payload.