### PR TITLE
Add HEDWIG_POST_PROCESS_HOOK

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -139,6 +139,10 @@ It's recommended that this function be declared with ``**kwargs`` so it doesn't 
 
 optional; fully-qualified function name
 
+**HEDWIG_POST_PROCESS_HOOK**
+
+Same as ``HEDWIG_PRE_PROCESS_HOOK`` but executed after message processing.
+
 **HEDWIG_POST_DESERIALIZE_HOOK**
 
 A function which can used to plug into the message processing pipeline *after* serializing from JSON succeeds. This

--- a/hedwig/conf/__init__.py
+++ b/hedwig/conf/__init__.py
@@ -30,6 +30,7 @@ _DEFAULTS = {
     'HEDWIG_MESSAGE_ROUTING': {},
     'HEDWIG_POST_DESERIALIZE_HOOK': 'hedwig.conf.noop_hook',
     'HEDWIG_PRE_PROCESS_HOOK': 'hedwig.conf.noop_hook',
+    'HEDWIG_POST_PROCESS_HOOK': 'hedwig.conf.noop_hook',
     'HEDWIG_PRE_SERIALIZE_HOOK': 'hedwig.conf.noop_hook',
     'HEDWIG_PUBLISHER': None,
     'HEDWIG_QUEUE': None,
@@ -44,6 +45,7 @@ _IMPORT_STRINGS = (
     'HEDWIG_DEFAULT_HEADERS',
     'HEDWIG_POST_DESERIALIZE_HOOK',
     'HEDWIG_PRE_PROCESS_HOOK',
+    'HEDWIG_POST_PROCESS_HOOK',
     'HEDWIG_PRE_SERIALIZE_HOOK',
 )
 

--- a/hedwig/publisher.py
+++ b/hedwig/publisher.py
@@ -71,6 +71,7 @@ def dispatch_mock_sqs_message(message: Message) -> None:
     sqs_message.receipt_handle = 'test-receipt'
     settings.HEDWIG_PRE_PROCESS_HOOK(sqs_queue_message=sqs_message)
     consumer.message_handler_sqs(sqs_message)
+    settings.HEDWIG_POST_PROCESS_HOOK(sqs_queue_message=sqs_message)
 
 
 def publish(message: Message) -> None:

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -158,6 +158,7 @@ def test_get_default_queue_name():
 
 
 pre_process_hook = mock.MagicMock()
+post_process_hook = mock.MagicMock()
 post_deserialize_hook = mock.MagicMock()
 
 
@@ -214,6 +215,33 @@ class TestFetchAndProcessMessages:
         fetch_and_process_messages(queue_name, queue)
 
         pre_process_hook.assert_has_calls([mock.call(sqs_queue_message=x) for x in mock_get_messages.return_value])
+
+    def test_post_process_hook(self, mock_message_handler, mock_get_messages, settings):
+        queue_name = 'my-queue'
+        queue = mock.MagicMock()
+        settings.HEDWIG_POST_PROCESS_HOOK = 'tests.test_consumer.post_process_hook'
+
+        mock_get_messages.return_value = [mock.MagicMock(), mock.MagicMock()]
+
+        fetch_and_process_messages(queue_name, queue)
+
+        post_process_hook.assert_has_calls([mock.call(sqs_queue_message=x) for x in mock_get_messages.return_value])
+
+    def test_post_process_hook_exception_raised(self, mock_message_handler, mock_get_messages, settings):
+        queue_name = 'my-queue'
+        queue = mock.MagicMock()
+        settings.HEDWIG_POST_PROCESS_HOOK = 'tests.test_consumer.post_process_hook'
+
+        mock_message = mock.MagicMock()
+        mock_get_messages.return_value = [mock_message]
+
+        post_process_hook.reset_mock()
+        post_process_hook.side_effect = RuntimeError('fail')
+
+        fetch_and_process_messages(queue_name, queue)
+
+        post_process_hook.assert_called_once_with(sqs_queue_message=mock_message)
+        mock_message.delete.assert_not_called()
 
 
 @mock.patch('hedwig.consumer.message_handler_lambda', autospec=True)


### PR DESCRIPTION
HEDWIG_PRE_PROCESS_HOOK is for initialization, but initialization often comes with required cleanup, so HEDWIG_POST_PROCESS_HOOK is useful too.