### PR TITLE
Stringify schema errors to avoid "unprintable error" messages in pytest and others

### DIFF
--- a/hedwig/validator.py
+++ b/hedwig/validator.py
@@ -88,7 +88,7 @@ class MessageValidator(Draft4Validator):
                 errors.append(f"Schema not found for '{msg_type}' v{version_pattern}")
 
         if errors:
-            raise SchemaError(errors)
+            raise SchemaError(str(errors))
 
     @staticmethod
     @FormatChecker.cls_checks('human-uuid')


### PR DESCRIPTION
Example from pytest traceback:

```
        if errors:
>           raise SchemaError(errors)
E           jsonschema.exceptions.SchemaError: <unprintable SchemaError object>
```